### PR TITLE
Improved `everyPairWithoutDuplicates` and `mapEveryPair`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "FunctionTools", url: "https://github.com/RougeWare/Swift-Function-Tools", from: "1.1.0"),
+        .package(name: "FunctionTools", url: "https://github.com/RougeWare/Swift-Function-Tools", from: "1.2.0"),
     ],
     
     targets: [

--- a/Sources/CollectionTools/Collection + everyPair.swift
+++ b/Sources/CollectionTools/Collection + everyPair.swift
@@ -36,16 +36,37 @@ public extension Collection {
     /// - Parameter mapper: The function which maps each pair of elements to a new collection
     /// - Returns: A new collection of the elements you transformed this one into
     func mapEveryPair
-        <ProcessedElement, ProcessedCollection>
-        (_ mapper: Transformer<(Element, Element), ProcessedElement>)
-        -> ProcessedCollection
-        where ProcessedCollection: RangeReplaceableCollection,
-            ProcessedCollection: CollectionWhichCanBeEmpty,
-            ProcessedCollection.Element == ProcessedElement
+        <ProcessedElement>
+        (_ mapper: @escaping Transformer<(Element, Element), ProcessedElement>)
+        -> EveryPairMapped<ProcessedElement>
     {
-        everyPair.reduce(into: .init()) { (result, element) in
-            result.append(mapper(element))
-        }
+        everyPair.map(mapper)
+    }
+    
+    
+    /// Turns this collection into a lazy sequence of every element paired up with every other element
+    ///
+    /// - Parameter equator: The function which will define equality
+    func everyPairWithoutDuplicates(equatingBy equator: @escaping Transformer<(Element, Element), Bool>) -> EveryPairWithoutDuplicates {
+        everyPair.filter(!equator)
+    }
+    
+    
+    /// Pairs up every element with every other element and passes them to the given transformer, resulting in a
+    /// collection of the transformed elements
+    ///
+    /// - Parameter mapper: The function which maps each pair of elements to a new collection
+    /// - Returns: A new collection of the elements you transformed this one into
+    func mapEveryPairWithoutDuplicates
+        <ProcessedElement>
+        (
+            equatingBy equator: @escaping Transformer<(Element, Element), Bool>,
+            _ mapper: @escaping Transformer<(Element, Element), ProcessedElement>
+        )
+        -> EveryPairWithoutDuplicatesMapped<ProcessedElement>
+    {
+        everyPairWithoutDuplicates(equatingBy: equator)
+            .map(mapper)
     }
     
     
@@ -69,6 +90,9 @@ public extension Collection {
     
     
     typealias EveryPair = LazySequence<EveryPairBase>
+    typealias EveryPairMapped<ProcessedElement> = LazyMapSequence<EveryPairBase, ProcessedElement>
+    typealias EveryPairWithoutDuplicates = LazyFilterSequence<EveryPairBase>
+    typealias EveryPairWithoutDuplicatesMapped<ProcessedElement> = LazyMapSequence<EveryPairWithoutDuplicates, ProcessedElement>
 }
 
 
@@ -87,19 +111,11 @@ public extension Collection where Element: Equatable {
     /// - Parameter mapper: The function which maps each pair of elements to a new collection
     /// - Returns: A new collection of the elements you transformed this one into
     func mapEveryPairWithoutDuplicates
-        <ProcessedElement, ProcessedCollection>
-        (_ mapper: Transformer<(Element, Element), ProcessedElement>)
-        -> ProcessedCollection
-        where ProcessedCollection: RangeReplaceableCollection,
-            ProcessedCollection: CollectionWhichCanBeEmpty,
-            ProcessedCollection.Element == ProcessedElement
+        <ProcessedElement>
+        (_ mapper: @escaping Transformer<(Element, Element), ProcessedElement>)
+        -> EveryPairWithoutDuplicatesMapped<ProcessedElement>
     {
-        everyPairWithoutDuplicates.reduce(into: .init()) { (result, element) in
-            result.append(mapper(element))
-        }
+        everyPairWithoutDuplicates
+            .map(mapper)
     }
-    
-    
-    
-    typealias EveryPairWithoutDuplicates = LazyFilterSequence<EveryPairBase>
 }

--- a/Tests/CollectionToolsTests/Collection + everyPair Tests.swift
+++ b/Tests/CollectionToolsTests/Collection + everyPair Tests.swift
@@ -16,7 +16,7 @@ final class Collection_plus_everyPair_Tests: XCTestCase {
     
     func test_everyPair() {
         let testString = "Lorem"
-        XCTAssertEqual(Array(testString.everyPair.map { String([$0.0, $0.1]) }), [
+        XCTAssertEqual(Array(testString.everyPair.map { "\($0.0)\($0.1)" }), [
             "LL", "Lo", "Lr", "Le", "Lm",
             "oL", "oo", "or", "oe", "om",
             "rL", "ro", "rr", "re", "rm",
@@ -28,7 +28,7 @@ final class Collection_plus_everyPair_Tests: XCTestCase {
     
     func test_everyPairWithoutDuplicates() {
         let testString = "Lorem"
-        XCTAssertEqual(Array(testString.everyPairWithoutDuplicates.map { String([$0.0, $0.1]) }), [
+        XCTAssertEqual(Array(testString.everyPairWithoutDuplicates.map { "\($0.0)\($0.1)" }), [
                   "Lo", "Lr", "Le", "Lm",
             "oL",       "or", "oe", "om",
             "rL", "ro",       "re", "rm",
@@ -40,7 +40,7 @@ final class Collection_plus_everyPair_Tests: XCTestCase {
     
     func test_mapEveryPair() {
         let testString = "Lorem"
-        XCTAssertEqual(testString.mapEveryPair { String([$0.0, $0.1]) }, [
+        XCTAssertEqual(Array(testString.mapEveryPair { "\($0.0)\($0.1)" }), [
             "LL", "Lo", "Lr", "Le", "Lm",
             "oL", "oo", "or", "oe", "om",
             "rL", "ro", "rr", "re", "rm",
@@ -52,12 +52,39 @@ final class Collection_plus_everyPair_Tests: XCTestCase {
     
     func test_mapEveryPairWithoutDuplicates() {
         let testString = "Lorem"
-        XCTAssertEqual(testString.mapEveryPairWithoutDuplicates { String([$0.0, $0.1]) }, [
+        XCTAssertEqual(Array(testString.mapEveryPairWithoutDuplicates { "\($0.0)\($0.1)" }), [
                   "Lo", "Lr", "Le", "Lm",
             "oL",       "or", "oe", "om",
             "rL", "ro",       "re", "rm",
             "eL", "eo", "er",       "em",
             "mL", "mo", "mr", "me",
+        ])
+        
+        
+        
+        struct KindaEquatable {
+            let value: Int
+        }
+        
+        
+        
+        let testKindaEquatableArray = [
+            KindaEquatable(value: 1),
+            KindaEquatable(value: 2),
+            KindaEquatable(value: 3),
+            KindaEquatable(value: 4),
+        ]
+        
+        let x = testKindaEquatableArray.mapEveryPairWithoutDuplicates(
+            equatingBy: { $0.value == $1.value },
+            { "\($0.value)\($1.value)" }
+        )
+        
+        XCTAssertEqual(Array(x), [
+                  "12", "13", "14",
+            "21",       "23", "24",
+            "31", "32",       "34",
+            "41", "42", "43",
         ])
     }
     


### PR DESCRIPTION
Better generics, more laziness, allow remove duplicates without `Equatable`
