### PR TITLE
`OptionSet` auto synthesis for `CaseIterable`s whose cases are `BinaryIntegers`

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "container:../..">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Sources/CollectionTools/enum + OptionSet + CaseIterable.swift
+++ b/Sources/CollectionTools/enum + OptionSet + CaseIterable.swift
@@ -1,0 +1,30 @@
+//
+//  enum + OptionSet + CaseIterable.swift
+//  Project Eve for iOS
+//
+//  Created by Ben Leggiero on 2020-07-16.
+//  Copyright © 2020 PKWARE, Inc. All rights reserved.
+//
+
+import Foundation
+
+
+
+public extension OptionSet
+    where Self: CaseIterable,
+          RawValue: BinaryInteger,
+          AllCases.Element == Element
+{
+    /// Regenerates this option set by querying all the possible cases
+    ///
+    /// - Parameter rawValue: The desired raw value of this option set after reconstruction
+    init(rawValue: RawValue) {
+        self = []
+        
+        for option in Self.allCases
+            where 0 != (rawValue & (1 << option.rawValue))
+        {
+            self.insert(option)
+        }
+    }
+}


### PR DESCRIPTION
Turn this:

```swift
struct MyOptions: OptionSet {
    var rawValue: UInt8

    static let foo = Self(rawValue: 1 << 0)
    static let bar = Self(rawValue: 1 << 1)
    static let baz = Self(rawValue: 1 << 2)
}
```

Into this:

```swift
enum MyOptions: UInt8, OptionSet, CaseIterable {
    case foo
    case bar
    case baz
}
```