### PR TITLE
Implemented `.sequentialPairs`

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "container:../..">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Sources/CollectionTools/Collection + sequentialPairs.swift
+++ b/Sources/CollectionTools/Collection + sequentialPairs.swift
@@ -1,0 +1,32 @@
+//
+//  Collection + sequentialPairs.swift
+//  
+//
+//  Created by Ben Leggiero on 2020-08-02.
+//
+
+import Foundation
+
+
+
+public extension Sequence {
+    /// Returns all the pairs in this sequence, in the order in which they appear.
+    ///
+    /// For example, given this array:
+    /// ```swift
+    /// ["A", "B", "C", "D", "E"].sequentialPairs
+    /// ```
+    ///
+    /// This will give a sequence like this:
+    /// ```swift
+    /// [
+    ///     ("A", "B"),
+    ///     ("B", "C"),
+    ///     ("C", "D"),
+    ///     ("D", "E"),
+    /// ]
+    /// ```
+    var sequentialPairs: Zip2Sequence<Self, DropFirstSequence<Self>> {
+        zip(self, self.dropFirst())
+    }
+}

--- a/Tests/CollectionToolsTests/Collection + sequentialPairs Tests.swift
+++ b/Tests/CollectionToolsTests/Collection + sequentialPairs Tests.swift
@@ -1,0 +1,24 @@
+//
+//  Collection + sequentialPairs Tests.swift
+//  
+//
+//  Created by Ben Leggiero on 2020-08-02.
+//
+
+import XCTest
+import CollectionTools
+
+
+
+final class Collection_plus_sequentialPairs_Tests: XCTestCase {
+    
+    func test_sequentialPairs() {
+        let pairs = Array(["A", "B", "C", "D", "E"].sequentialPairs)
+        
+        XCTAssertEqual(pairs.count, 4)
+        XCTAssertEqual(pairs[0].0, "A"); XCTAssertEqual(pairs[0].1, "B")
+        XCTAssertEqual(pairs[1].0, "B"); XCTAssertEqual(pairs[1].1, "C")
+        XCTAssertEqual(pairs[2].0, "C"); XCTAssertEqual(pairs[2].1, "D")
+        XCTAssertEqual(pairs[3].0, "D"); XCTAssertEqual(pairs[3].1, "E")
+    }
+}


### PR DESCRIPTION
This allows you to lazily consume any sequence as a series of its ordered pairs